### PR TITLE
feeature request: enable enviroment variable for configuration

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -15,6 +15,7 @@ fn main() {
     let mut conf = config_rs::Config::new();
     let config_file = dotenv::var("CLIENT_CONFIG").unwrap();
     conf.merge(config_rs::File::with_name(&config_file)).unwrap();
+    conf.merge(config_rs::Environment::with_prefix("client")).unwrap();
     let settings: config::Settings = conf.try_into().unwrap();
     log::debug!("{:?}", settings);
 

--- a/src/bin/coordinator.rs
+++ b/src/bin/coordinator.rs
@@ -9,6 +9,7 @@ fn main() {
     let mut conf = config_rs::Config::new();
     let config_file = dotenv::var("COORDINATOR_CONFIG").unwrap();
     conf.merge(config_rs::File::with_name(&config_file)).unwrap();
+    conf.merge(config_rs::Environment::with_prefix("coordinator")).unwrap();
     let settings: config::Settings = conf.try_into().unwrap();
     log::debug!("{:?}", settings);
 

--- a/src/coordinator/controller.rs
+++ b/src/coordinator/controller.rs
@@ -16,7 +16,7 @@ impl Controller {
     pub async fn from_config(config: &Settings) -> anyhow::Result<Self> {
         let db_conn = ConnectionType::connect(&config.db).await?;
         Ok(Self {
-            db_conn: db_conn,
+            db_conn,
             // tasks: BTreeMap::new(),
         })
     }
@@ -32,7 +32,7 @@ impl Controller {
                 log::debug!("task input: {:?}", t.input.to_string());
 
                 // self.tasks.remove(&t.task_id);
-                self.assign_task(t.clone().task_id, request.prover_id).await;
+                self.assign_task(t.clone().task_id, request.prover_id).await.unwrap();
                 Ok(Task {
                     circuit: request.circuit,
                     id: t.clone().task_id,
@@ -63,7 +63,7 @@ impl Controller {
     pub async fn submit_proof(&mut self, req: SubmitProofRequest) -> Result<SubmitProofResponse, Status> {
         // TODO: validate proof
 
-        self.store_proof(req).await;
+        self.store_proof(req).await.unwrap();
 
         Ok(SubmitProofResponse { valid: true })
     }

--- a/src/coordinator/db/mod.rs
+++ b/src/coordinator/db/mod.rs
@@ -1,5 +1,3 @@
-use sqlx;
-
 pub type DbType = sqlx::Postgres;
 pub type ConnectionType = sqlx::postgres::PgConnection;
 pub type DBErrType = sqlx::Error;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::module_inception)]
 pub use config::Settings;
 pub use controller::Controller;
 pub use coordinator::Coordinator;

--- a/src/coordinator/witness_factory.rs
+++ b/src/coordinator/witness_factory.rs
@@ -30,9 +30,9 @@ impl WitnessFactory {
         }
 
         Ok(Self {
-            db_conn: db_conn,
+            db_conn,
             witgen_interval: config.witgen.interval(),
-            circuits: circuits,
+            circuits,
         })
     }
 
@@ -45,7 +45,7 @@ impl WitnessFactory {
             log::debug!("ticktock!");
 
             let task = self.claim_one_task().await.expect("claim_one_task");
-            if let None = task {
+            if task.is_none() {
                 continue;
             }
             let task = task.unwrap();
@@ -70,7 +70,7 @@ impl WitnessFactory {
             // decide circuit
             let circuit_name = format!("{:?}", task.circuit).to_lowercase();
             log::debug!("circuit_name: {:?}", circuit_name);
-            if let None = self.circuits.get(&circuit_name) {
+            if self.circuits.get(&circuit_name).is_none() {
                 log::error!("unknown circuit: {:?}", circuit_name);
                 continue;
             }


### PR DESCRIPTION
This PR simply enable using environment variable in configuration. I think it is urgent for dynamic deploying in a production context, like the k8s cluster.

The client and coordinator would recognized environment variables with "client" and "coordinator" prefix respectively