### PR TITLE
feature: listen address of coordinator is configurable

### DIFF
--- a/src/bin/coordinator.rs
+++ b/src/bin/coordinator.rs
@@ -20,7 +20,7 @@ fn main() {
     main_runtime
         .block_on(async {
             let server = Coordinator::from_config(&settings).await.expect("init server error");
-            let addr = format!("[::1]:{:?}", settings.port).parse().unwrap();
+            let addr = format!("{}:{:?}", settings.listenaddr, settings.port).parse().unwrap();
             grpc_run(server, addr).await
         })
         .unwrap();

--- a/src/coordinator/config.rs
+++ b/src/coordinator/config.rs
@@ -2,8 +2,14 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::time::Duration;
 
+fn default_addr() -> String {
+    "[::1]".to_string()
+}
+
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct Settings {
+    #[serde(default = "default_addr")]
+    pub listenaddr: String,
     pub port: u64,
     pub db: String,
     pub witgen: WitGen,


### PR DESCRIPTION
This PR add a configure entry for the listening address of coordinator so it would be work under production environment

The default listening address is still a ipv6 compatible loopback address ([::1])