### PR TITLE
fix: truncate prover id

### DIFF
--- a/src/coordinator/controller.rs
+++ b/src/coordinator/controller.rs
@@ -81,7 +81,8 @@ impl Controller {
     }
 
     // Failure is acceptable here. We can re-assign the task to another prover later.
-    async fn assign_task(&mut self, task_id: String, prover_id: String) -> anyhow::Result<()> {
+    async fn assign_task(&mut self, task_id: String, mut prover_id: String) -> anyhow::Result<()> {
+        prover_id.truncate(30);
         let stmt = format!("update {} set prover_id = $1, status = $2 where task_id = $3", tablenames::TASK);
         sqlx::query(&stmt)
             .bind(prover_id)
@@ -98,10 +99,12 @@ impl Controller {
             "update {} set public_input = $1, proof = $2, prover_id = $3, status = $4 where task_id = $5",
             tablenames::TASK
         );
+        let mut prover_id = req.prover_id.clone();
+        prover_id.truncate(30);
         sqlx::query(&stmt)
             .bind(req.public_input)
             .bind(req.proof)
-            .bind(req.prover_id)
+            .bind(prover_id)
             .bind(task::TaskStatus::Proved)
             .bind(req.task_id)
             .execute(&self.db_pool)


### PR DESCRIPTION
This PR purpose a way to fix issue #61 in which a too long prover_id assigned to client crash the request for assignment and submitting.

Long prover id seems to be inevitable when we start to made use of sophisticated deployment. Many schemes for automatic assignment of prover id, like a well formatted uuid, would exceed 30 chars limited in db. So currently the best way to resolve such problem is to truncate them if coordinator had received too long one.