### PR TITLE
Chore updates for dependency and stuffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 [[package]]
 name = "fluidex-common"
 version = "0.1.0"
-source = "git+https://github.com/fluidex/common-rs?branch=master#a6a2b252a0a2dfd92726491d32008fcfef5033ef"
+source = "git+https://github.com/fluidex/common-rs?branch=master#769e979cf6efef9b157b3b00873e2d5ed4c94d5b"
 dependencies = [
  "anyhow",
  "babyjubjub-rs",

--- a/deploy/config/client.yaml
+++ b/deploy/config/client.yaml
@@ -1,8 +1,10 @@
 prover_id: 1
 upstream: "http://cluster_coordinator:50055"
 poll_interval: 10000
-circuit: "block"
-r1cs: "/opt/test/circuit.r1cs"
 srs_monomial_form: "/opt/mon.key"
-srs_lagrange_form: "/opt/test/lag.key"
-vk: "/opt/test/vk.bin"
+circuit:
+  name: "block"
+  bin: "/opt/test/circuit.fast"
+  r1cs: "/opt/test/circuit.r1cs"
+  srs_lagrange_form: "/opt/test/lag.key"
+

--- a/deploy/config/coordinator.yaml
+++ b/deploy/config/coordinator.yaml
@@ -1,8 +1,6 @@
 listenaddr: 0.0.0.0
 port: 50055
-db: postgres://coordinator:coordinator_AA9944@exchange_pq/prover_cluster
-witgen:
-  interval: 10000
-  n_workers: 5
-  circuits:
-    block: "/opt/circuit_test/circuit.fast"
+db: postgres://rollup:rollup_AA9944@exchange_pq/rollup
+circuits:
+  block: 
+    vk: "/opt/test/vk.bin"

--- a/deploy/images/plonkit.docker
+++ b/deploy/images/plonkit.docker
@@ -1,4 +1,4 @@
-FROM rust:1.51.0-buster
+FROM rust:1.55.0-buster
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \

--- a/deploy/images/prover.docker
+++ b/deploy/images/prover.docker
@@ -1,4 +1,4 @@
-FROM rust:1.51.0-buster
+FROM rust:1.56.0-buster
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
@@ -19,7 +19,7 @@ RUN apt-get install -y --no-install-recommends \
 RUN rustup component add rustfmt
 WORKDIR /opt
 RUN git clone https://github.com/fluidex/prover-cluster.git
-RUN cd prover-cluster && rustup override set 1.51.0 && cargo build --release
+RUN cd prover-cluster && cargo build --release
 
-FROM rust:1.51.0-buster
+FROM rust:1.56.0-buster
 COPY --from=0 /opt/prover-cluster/target/release/client /opt/prover-cluster/target/release/coordinator /usr/local/bin

--- a/deploy/images/setup.docker
+++ b/deploy/images/setup.docker
@@ -1,4 +1,4 @@
-FROM rust:1.51.0-buster as plonkit
+FROM rust:1.55.0-buster as plonkit
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \

--- a/src/client/watch.rs
+++ b/src/client/watch.rs
@@ -50,7 +50,12 @@ impl Watcher {
                     self.is_busy.store(true, Ordering::SeqCst);
 
                     let task = match self.grpc_client.poll_task().await {
-                        Ok(t) => t,
+                        Ok(Some(t)) => t,
+                        Ok(None) => {
+                            log::debug!("no task");
+                            self.is_busy.store(false, Ordering::SeqCst);
+                            continue;
+                        }
                         Err(e) => {
                             log::error!("poll task error {:?}", e);
                             self.is_busy.store(false, Ordering::SeqCst);


### PR DESCRIPTION
The dependency of fluidex-common has been updated to fix the incompatible of migration to the new schema of rollup db.

The stuffs under deploy directory has been also upgraded.

A trivial fix has been added to make client not complain with error log when receiving nothing from coordinator